### PR TITLE
Fix RIOTBASE relative path

### DIFF
--- a/task-06/Makefile
+++ b/task-06/Makefile
@@ -5,7 +5,7 @@ APPLICATION = Task04
 BOARD ?= native
 
 # This has to be the absolute path to the RIOT base directory:
-RIOTBASE ?= $(CURDIR)/../../RIOT
+RIOTBASE ?= $(CURDIR)/../RIOT
 
 # Uncomment this to enable scheduler statistics for ps:
 #CFLAGS += -DSCHEDSTATISTICS


### PR DESCRIPTION
RIOTBASE is wrong in task6 example
