### PR TITLE
task06: fixed off-by-one error for null-terminated server_buffer

### DIFF
--- a/task-06/udp.c
+++ b/task-06/udp.c
@@ -33,7 +33,7 @@ void *_udp_server(void *args)
         int res;
         ipv6_addr_t src;
         size_t src_len = sizeof(ipv6_addr_t);
-        if ((res = conn_udp_recvfrom(&conn, server_buffer, sizeof(server_buffer),
+        if ((res = conn_udp_recvfrom(&conn, server_buffer, sizeof(server_buffer) - 1,
                                      &src, &src_len, &port)) < 0) {
             puts("Error while receiving");
         }


### PR DESCRIPTION
When conn_udp_recvfrom() returns a positive value a null byte is
added at position res hence only sizeof(server_buffer) - 1 bytes
must be filled.
