### PR TITLE
vagrant: add Vagrantfile for the Tutorials repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin
 .swp
 *~
 *.pdf
+.vagrant

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For links go to [https://github.com/RIOT-OS/Tutorials](https://github.com/RIOT-O
     git submodule update --init --recursive
     ```
 * Change to the `RIOT` directory: `cd Tutorials/RIOT/`
-* Run `vagrant up tutorials` and `vagrant ssh tutorials` afterwards. See the [Vagrant RIOT Setup](https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/vagrant/README.md) for a more general explanation.
+* Run `vagrant up` and `vagrant ssh` afterwards. See the [Vagrant RIOT Setup](https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/vagrant/README.md) for a more general explanation.
 
 **Recommended Setup** (Without Using a VM)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'fileutils'
+
+riot_vagrantfile = File.expand_path('RIOT/Vagrantfile')
+RIOTBASE ||= "RIOT/"
+
+if File.exists?(riot_vagrantfile)
+    load riot_vagrantfile
+else
+    abort "No Vagrantfile found in the RIOT directory. ABORTING!"
+end
+
+Vagrant.configure(2) do |config|
+  config.vm.provider "virtualbox" do |vb|
+    vb.name = "RIOT VM - Tutorials"
+  end
+  config.vm.synced_folder ".", "/home/vagrant/Tutorials"
+end


### PR DESCRIPTION
This new `Vagrantfile` loads the `Vagrantfile` that is located in the `RIOT`
directory and furthermore adds the `Tutorials` directory as a synced
folder to the virtual machine.

see https://github.com/RIOT-OS/RIOT/pull/5853
