### PR TITLE
change name of vagrant box

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For links go to [https://github.com/RIOT-OS/Tutorials](https://github.com/RIOT-O
     git submodule update --init --recursive
     ```
 * Change to the `RIOT` directory: `cd Tutorials/RIOT/`
-* In case a virtual machine is disseminated locally, adapt the path for the vagrant box `vagrant box add RIOT-VM <path to box>`
+* In case a virtual machine is disseminated locally, adapt the path for the vagrant box `vagrant box add RIOT/ubuntu1604 <path to box>`
 * Run `vagrant up` and `vagrant ssh` afterwards. See the [Vagrant RIOT Setup](https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/vagrant/README.md) for a more general explanation.
 
 **Recommended Setup** (Without Using a VM)


### PR DESCRIPTION
This seems to be mandatory. It's a bug in the doc and I need this fixed so I merge immediately
