### PR TITLE
Fixes missing txtsnd command from task-05 and task-06

### DIFF
--- a/task-05/Makefile
+++ b/task-05/Makefile
@@ -20,6 +20,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += gnrc_pktdump
+USEMODULE += gnrc_txtsnd
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 

--- a/task-06/Makefile
+++ b/task-06/Makefile
@@ -27,5 +27,6 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_conn_udp
+USEMODULE += gnrc_txtsnd
 
 include $(RIOTBASE)/Makefile.include

--- a/task-06/Makefile
+++ b/task-06/Makefile
@@ -27,6 +27,5 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_conn_udp
-USEMODULE += gnrc_txtsnd
 
 include $(RIOTBASE)/Makefile.include

--- a/task-06/README.md
+++ b/task-06/README.md
@@ -29,7 +29,6 @@ USEMODULE += gnrc_conn_udp
    random_init          initializes the PRNG
    random_get           returns 32 bit of pseudo randomness
    ifconfig             Configure network interfaces
-   txtsnd               Sends a custom string as is over the link layer
    ncache               manage neighbor cache by hand
    routers              IPv6 default router list
    >


### PR DESCRIPTION
The command is used in the instructions but somehow was missing from the Makefiles