### PR TITLE
Added missing modules to README.md.

### DIFF
--- a/task-06/README.md
+++ b/task-06/README.md
@@ -8,6 +8,8 @@ The transport layer (UDP, TCP, etc) is accessed through [`sock`](https://doc.rio
 
 Look at the new modules in the [`Makefile`](Makefile)
 ```
+USEMODULE += gnrc_ipv6_default
+USEMODULE += gnrc_icmpv6_echo
 USEMODULE += gnrc_sock_udp
 ```
 


### PR DESCRIPTION
Good Morning,

I had a problem following this task since the README just tells you to include `USEMODULE += gnrc_sock_udp`, while you are required to add the `gnrc_ipv6_default` and `gnrc_icmpv6_echo`.
This took me hours to debug, thinking I had done something wrong. 
The Makefile is correct, but I was only following the README (because I wanted to do it by myself) and I think more people may have the same mentality. 
Knowing this, I propose to add the new modules (compared to Task 05) to the README.md so the next people following this tutorial don't make the same mistake. 

Thank you for your time,
Bernardo Belchior