### PR TITLE
slides: update LED0_TOGGLE header

### DIFF
--- a/slides/slides.md
+++ b/slides/slides.md
@@ -151,7 +151,7 @@ foobar
 ```
 
 ## Task 2.2 -- Control the hardware
-* `board.h` defines a macro `LED0_TOGGLE` to toggle the primary LED on the board.
+* `led.h` defines a macro `LED0_TOGGLE` to toggle the primary LED on the board.
 * Write a command handler `toggle` in main.c that toggles the primary LED on the board
 
 # Multithreading


### PR DESCRIPTION
This was updated in 9bb0d1f415c25c2f99779faa61c230acfd6e33e1 for the corresponding README, but not in the slide set.