### PR TITLE
treewide: drop mention of ping6

### DIFF
--- a/slides/slides.md
+++ b/slides/slides.md
@@ -431,7 +431,7 @@ Pseudo-module dependencies
 * Ping RIOT instance from Linux:
 
 ```sh
-ping6 <RIOT-IPv6-addr>%tap0
+ping <RIOT-IPv6-addr>%tap0
 ```
 
 ## `gnrc_minimal` example (`samr21-xpro`)

--- a/task-06/README.md
+++ b/task-06/README.md
@@ -29,7 +29,6 @@ USEMODULE += gnrc_sock_udp
    version              Prints current RIOT_VERSION
    pm                   interact with layered PM subsystem
    ps                   Prints information about running threads.
-   ping6                Ping via ICMPv6
    ping                 Ping via ICMPv6
    random_init          initializes the PRNG
    random_get           returns 32 bit of pseudo randomness

--- a/task-07/README.md
+++ b/task-07/README.md
@@ -15,7 +15,7 @@ It uses the [example applications in the RIOT repository](https://github.com/RIO
 * Ping RIOT instance from Linux:
 
 ```sh
-ping6 <RIOT-IPv6-addr>%tapbr0
+ping <RIOT-IPv6-addr>%tapbr0
 ```
 Note: on MAC use `bridge0` instead of `tapbr0`.
 

--- a/task-09/README.md
+++ b/task-09/README.md
@@ -53,6 +53,6 @@ rpl root 1 2001:db8::1
 
 ## Pinging "distant" nodes
 
-* Use the ping6 command to ping global address of a "distant" node.
+* Use the ping command to ping global address of a "distant" node.
 * Most likely, in this setup the root node will be the only intermediate hop. It should print some rough information about forwarding IPv6 packets
 * Additionally you can try to transmit UDP packets (explore the `udp` commandset)


### PR DESCRIPTION
This is just an alias to the `ping` command, we want to drop it eventually.