### PR TITLE
Tasks: Changed ".doc" links to ".api" to fix broken links.

### DIFF
--- a/task-02/README.md
+++ b/task-02/README.md
@@ -30,11 +30,11 @@ static const shell_command_t shell_commands[] = {
 Please note, that the list of shell commands must be terminated with an empty entry.
 
 ## Task 2.2: Control the hardware
-1.  Include the [`led.h`](https://doc.riot-os.org/led_8h.html) file to get access
+1.  Include the [`led.h`](https://api.riot-os.org/led_8h.html) file to get access
     to the `LED0_TOGGLE` macro.
 2.  Write a command handler `toggle` in [`main.c`](main.c) that toggles the
     primary LED on the board using the `LED0_TOGGLE` macro.
 
-[Read the Doc](https://doc.riot-os.org/group__sys__shell.html)
+[Read the Doc](https://api.riot-os.org/group__sys__shell.html)
 
 [next task](../task-03)

--- a/task-03/README.md
+++ b/task-03/README.md
@@ -5,8 +5,8 @@ Threads in RIOT are functions with signature
 ```C
 void *thread_handler(void *arg);
 ```
-Use [`thread_create()`](https://doc.riot-os.org/thread_8h.html#a87c94d383e64a09974fc8665f82a99b3) from
-[`thread.h`](https://doc.riot-os.org/thread_8h.html) to start it
+Use [`thread_create()`](https://api.riot-os.org/group__core__thread.html#ga7e0403a9aa86ce0ec136f6b069d4434a) from
+[`thread.h`](https://api.riot-os.org/group__core__thread.html) to start it
 ```C
 thread_create(stack, sizeof(stack),
                     THREAD_PRIORITY_MAIN - 1,
@@ -21,6 +21,6 @@ thread_create returns a kernel_pid_t type, which can be helpful to assign to a v
 * Run the application on `native`: `make all term`
 * Check your output, it should read: `I'm in "thread" now`
 
-[Read the doc](https://doc.riot-os.org/group__core__thread.html)
+[Read the doc](https://api.riot-os.org/group__core__thread.html)
 
 [next task](../task-04)

--- a/task-04/README.md
+++ b/task-04/README.md
@@ -1,7 +1,7 @@
 [previous task](../task-03)
 
 # Task 4: Timers
-[`xtimer`](https://doc.riot-os.org/group__sys__xtimer.html) is the high level API of RIOT to multiplex hardware timers.
+[`xtimer`](https://api.riot-os.org/group__sys__xtimer.html) is the high level API of RIOT to multiplex hardware timers.
 For this task we need only the following functions
 
     - `xtimer_now_usec()` to get current system time in microseconds
@@ -16,6 +16,6 @@ USEMODULE += xtimer
 * Create a thread in [`main.c`](main.c#L12) that prints the current system time every 2 seconds
 * Check the existence of the thread with `ps` shell command
 
-[Read the doc](https://doc.riot-os.org/group__sys__xtimer.html)
+[Read the doc](https://api.riot-os.org/group__sys__xtimer.html)
 
 [next task](../task-05)

--- a/task-05/README.md
+++ b/task-05/README.md
@@ -3,7 +3,7 @@
 # Task 5: Using network devices
 
 ## RIOT's Networking architecture
-Network devices are accessed through [`netdev`](https://doc.riot-os.org/group__drivers__netdev__api.html) driver API
+Network devices are accessed through [`netdev`](https://api.riot-os.org/group__drivers__netdev__api.html) driver API
 
 ![Networking overview](../overview-net.png)
 
@@ -41,6 +41,6 @@ sudo ./../RIOT/dist/tools/tapsetup/tapsetup -c 2
 * Type `ifconfig` to get your hardware addresses
 * Use `txtsnd` to send one of your neighbors a friendly message
 
-[Read the Doc](https://doc.riot-os.org/group__drivers__netdev__api.html)
+[Read the Doc](https://api.riot-os.org/group__drivers__netdev__api.html)
 
 [next task](../task-06)

--- a/task-06/README.md
+++ b/task-06/README.md
@@ -2,7 +2,7 @@
 
 # 6. UDP Client / Server
 
-The transport layer (UDP, TCP, etc) is accessed through [`sock`](https://doc.riot-os.org/group__net__sock.html) driver API
+The transport layer (UDP, TCP, etc) is accessed through [`sock`](https://api.riot-os.org/group__net__sock.html) driver API
 
 ![Networking overview](../overview-net.png)
 
@@ -91,7 +91,7 @@ USEMODULE += gnrc_sock_udp
     ```
     udp <tap0-IPv6-addr> 8888 hello
     ```
-[Read the Doc](https://doc.riot-os.org/group__net__sock.html)
+[Read the Doc](https://api.riot-os.org/group__net__sock.html)
 
 ## Task 6.3 -- Exchange UDP packets with your neighbors
 * Compile, flash and run on the board `BOARD=samr21-xpro make all flash term`

--- a/task-07/README.md
+++ b/task-07/README.md
@@ -22,8 +22,8 @@ Note: on MAC use `bridge0` instead of `tapbr0`.
 ## Task 7.2: Extend `gnrc_minimal` application
 * Add the `gnrc_udp` module to the application's
 [Makefile](https://github.com/RIOT-OS/RIOT/blob/master/examples/gnrc_minimal/Makefile)
-* To be able to receive packets, a [message queue](http://doc.riot-os.org/group__net__gnrc.html) must be 
-  created using [msg_init_queue](https://doc.riot-os.org/group__core__msg.html#ga480e6f32c8ab18579b62a890f3fda2cd):
+* To be able to receive packets, a [message queue](http://api.riot-os.org/group__net__gnrc.html) must be 
+  created using [msg_init_queue](https://api.riot-os.org/group__core__msg.html#ga480e6f32c8ab18579b62a890f3fda2cd):
 
 ```C
 msg_t msg_queue[num];
@@ -33,7 +33,7 @@ msg_init_queue(msg_queue, num);
 Note: `num` must be in powers of 2.
 
 * You can register for packets of a certain type and context (port 8888 in our
-  case) using `gnrc_netreg_register()` from [`net/gnrc/netreg.h`](https://doc.riot-os.org/group__net__gnrc__netreg.html):
+  case) using `gnrc_netreg_register()` from [`net/gnrc/netreg.h`](https://api.riot-os.org/group__net__gnrc__netreg.html):
 * The current thread can be obtained with the `thread_getpid()` function from
   `thread.h`
 
@@ -42,7 +42,7 @@ gnrc_netreg_entry_t server = GNRC_NETREG_ENTRY_INIT_PID(8888, thread_getpid());
 gnrc_netreg_register(GNRC_NETTYPE_UDP, &server);
 ```
 
-* Packets can be received using the IPC receive function [msg_receive()](https://doc.riot-os.org/group__core__msg.html#gae3e05f08bd71d6f65dc727624c4d5f7a):
+* Packets can be received using the IPC receive function [msg_receive()](https://api.riot-os.org/group__core__msg.html#gae3e05f08bd71d6f65dc727624c4d5f7a):
 
 ```C
 msg_t msg;
@@ -74,6 +74,6 @@ gnrc_pktbuf_release(pkt);
 * Get your IPv6 address using `ifconfig`
 * Send your neighbor some messages using `udp send`
 
-[Read the Doc](https://doc.riot-os.org/group__net__gnrc.html)
+[Read the Doc](https://api.riot-os.org/group__net__gnrc.html)
 
 [next task](../task-08)


### PR DESCRIPTION
Not in task-08, because the documentation does not exist anymore.